### PR TITLE
Fix URL debian-10.10.0-amd64-netinst.iso

### DIFF
--- a/debian10.json
+++ b/debian10.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-      "vm_name": "debian-10.9.0-amd64",
+      "vm_name": "debian-10.10.0-amd64",
       "numvcpus": "1",
       "memsize": "1024",
       "disk_size": "40960",

--- a/debian10.json
+++ b/debian10.json
@@ -4,8 +4,8 @@
       "numvcpus": "1",
       "memsize": "1024",
       "disk_size": "40960",
-      "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.9.0-amd64-netinst.iso",
-      "iso_checksum": "8660593d10de0ce7577c9de4dab886ff540bc9843659c8879d8eea0ab224c109",
+      "iso_url": "https://cdimage.debian.org/mirror/cdimage/archive/10.10.0/amd64/iso-cd/debian-10.10.0-amd64-netinst.iso",
+      "iso_checksum": "c433254a7c5b5b9e6a05f9e1379a0bd6ab3323f89b56537b684b6d1bd1f8b6ad",
       "ssh_username" : "packer",
       "ssh_password" : "packer",
       "boot_wait": "5s"

--- a/debian10_uefi.json
+++ b/debian10_uefi.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-      "vm_name": "debian-10.9.0-amd64",
+      "vm_name": "debian-10.10.0-amd64",
       "numvcpus": "1",
       "memsize": "1024",
       "disk_size": "40960",

--- a/debian10_uefi.json
+++ b/debian10_uefi.json
@@ -4,8 +4,8 @@
       "numvcpus": "1",
       "memsize": "1024",
       "disk_size": "40960",
-      "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.9.0-amd64-netinst.iso",
-      "iso_checksum": "8660593d10de0ce7577c9de4dab886ff540bc9843659c8879d8eea0ab224c109",
+      "iso_url": "https://cdimage.debian.org/mirror/cdimage/archive/10.10.0/amd64/iso-cd/debian-10.10.0-amd64-netinst.iso",
+      "iso_checksum": "c433254a7c5b5b9e6a05f9e1379a0bd6ab3323f89b56537b684b6d1bd1f8b6ad",
       "ssh_username" : "packer",
       "ssh_password" : "packer",
       "boot_wait": "5s"


### PR DESCRIPTION
`"iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.9.0-amd64-netinst.iso",` link is dead.  
Replaced with:
"iso_url": "https://cdimage.debian.org/mirror/cdimage/archive/10.10.0/amd64/iso-cd/debian-10.10.0-amd64-netinst.iso",