### PR TITLE
Fix VirtualBox settings for functional Ethernet

### DIFF
--- a/debian10.json
+++ b/debian10.json
@@ -52,7 +52,12 @@
         "vm_name": "{{ user `vm_name` }}",
         "vboxmanage": [
           ["modifyvm", "{{.Name}}", "--memory", "{{ user `memsize` }}"],
-          ["modifyvm", "{{.Name}}", "--cpus", "{{ user `numvcpus` }}"]
+          ["modifyvm", "{{.Name}}", "--cpus", "{{ user `numvcpus` }}"],
+          ["modifyvm", "{{.Name}}", "--vram", "20"],
+          ["modifyvm", "{{.Name}}", "--graphicscontroller", "vmsvga"],
+          ["modifyvm", "{{.Name}}", "--acpi", "on"],
+          ["modifyvm", "{{.Name}}", "--ioapic", "on"],
+          ["modifyvm", "{{.Name}}", "--rtcuseutc", "on"]
         ]
       }
   ],


### PR DESCRIPTION
The following VirtualBox VM configuration settings are required in order to suppress warnings and functional DHCP at boottime:

* --vram: Minimum supported video RAM is 20MB
* --graphicscontroller: VirtualBox GUI strongly recommends `vmsvga`
* Default settings when creating a new VM (and fix Ethernet):
  * --acpi=on
  * --ioapic=on
  * --rtcuseutc=on

**Before the fix**:
```
ping <IP>
connect: Network is unreachable, cannot shutdown VM as it is waiting for link up.
Graphics warnings shown in VirtualBox GUI.
```

**After the fix**:
```
Ping and shutdown works as expected.
No warnings in VirtualBox GUI.
```

closes #7 